### PR TITLE
v1.3: Remove redundant log from UserSession

### DIFF
--- a/src/main/java/seedu/address/commons/core/session/UserSession.java
+++ b/src/main/java/seedu/address/commons/core/session/UserSession.java
@@ -26,7 +26,6 @@ public class UserSession {
     public static void login(Account account) {
         isAuthenticated = true;
         username = account.getUsername();
-        logger.info("Successfully logged in as \"" + username.toString() + "\".");
     }
 
     /**
@@ -35,7 +34,6 @@ public class UserSession {
     public static void logout() {
         if (isAuthenticated) {
             isAuthenticated = false;
-            logger.info("Successfully logged out from \"" + username.toString() + "\".");
             username = null;
         }
     }

--- a/src/main/java/seedu/address/commons/core/session/UserSession.java
+++ b/src/main/java/seedu/address/commons/core/session/UserSession.java
@@ -1,8 +1,5 @@
 package seedu.address.commons.core.session;
 
-import java.util.logging.Logger;
-
-import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.accounts.Account;
 import seedu.address.model.accounts.Username;
 
@@ -12,8 +9,6 @@ import seedu.address.model.accounts.Username;
  * sessions as it is impossible in this project's context.
  */
 public class UserSession {
-
-    private static final Logger logger = LogsCenter.getLogger(UserSession.class);
 
     private static boolean isAuthenticated = false;
     private static Username username;

--- a/src/main/java/seedu/address/logic/commands/accounts/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/accounts/LoginCommand.java
@@ -30,7 +30,7 @@ public class LoginCommand extends Command {
             + PREFIX_ID + "azhikai "
             + PREFIX_PASSWORD + "1122qq";
 
-    public static final String MESSAGE_SUCCESS = "Successfully logged in to %s!";
+    public static final String MESSAGE_SUCCESS = "Successfully logged in to '%s'!";
     public static final String MESSAGE_ACCOUNT_NOT_FOUND = "The account does not exist.";
     public static final String MESSAGE_WRONG_PASSWORD = "The credential is invalid.";
     public static final String MESSAGE_ALREADY_AUTHENTICATED = "You are already logged in.";

--- a/src/test/java/seedu/address/commons/core/session/UserSessionTest.java
+++ b/src/test/java/seedu/address/commons/core/session/UserSessionTest.java
@@ -5,27 +5,35 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.testutil.accounts.AccountBuilder;
 
 public class UserSessionTest {
 
+    @Before
+    public void setUp() {
+        if (!UserSession.isAuthenticated()) {
+            UserSession.login(new AccountBuilder().build());
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        // Make sure to unset the session, in case the last test case does logs out
+        UserSession.logout();
+    }
+
     @Test
     public void session_isAuthenticated() {
-        // check equality using the same base
-        UserSession.login(new AccountBuilder().build());
         assertTrue(UserSession.isAuthenticated());
         assertNotNull(UserSession.getUsername());
     }
 
     @Test
     public void session_isNotAuthenticated() {
-        // check equality using the same base
-        UserSession.login(new AccountBuilder().build());
-        assertTrue(UserSession.isAuthenticated());
-        assertNotNull(UserSession.getUsername());
-
         UserSession.logout();
         assertFalse(UserSession.isAuthenticated());
         assertNull(UserSession.getUsername());


### PR DESCRIPTION
This PR resolves #72 

Log is already stored when the command is executed. So let's remove the redundant logging from `UserSession`. And since command is already logged in the existing log file, let's just keep it that way (originally I thought it wasn't logged in the file).

**Ready for review**