### PR TITLE
Bug fixes

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -397,13 +397,14 @@ Deletes the ingredient `cod fish` from the ingredient list.
 ==== Editing an ingredient: `edit-ingredient` or `edit-ing`
 
 Edits an ingredient in the ingredient list. +
-Format: `edit-ingredient INDEX [n/INGREDIENT_NAME] [t/UNIT_TYPE] [p/PRICE_PER_UNIT] [m/MINIMUM]` or `edit-ingredient NAME [n/INGREDIENT_NAME] [t/UNIT_TYPE] [p/PRICE_PER_UNIT] [m/MINIMUM]`
+Format: `edit-ingredient [INDEX] [n/INGREDIENT_NAME] [u/UNIT_TYPE] [p/PRICE_PER_UNIT]
+[m/MINIMUM]` or `edit-ingredient on/ORIGINAL_INGREDIENT_NAME [n/NEW_INGREDIENT_NAME] [t/UNIT_TYPE] [p/PRICE_PER_UNIT] [m/MINIMUM]`
 
 [NOTE]
 ====
 * Edits the ingredient at the specified `INDEX`. The index refers to the index number shown in the displayed ingredient list. The index *must be a positive integer* 1, 2, 3, ...
 * Existing values will be updated to the input values.
-* Alternatively, edits the ingredient with the specified `NAME`.
+* Alternatively, edits the ingredient with the specified `ORIGNAL_INGREDIENT_NAME`.
 ====
 
 [WARNING]

--- a/src/main/java/seedu/restaurant/logic/commands/ingredient/EditIngredientCommand.java
+++ b/src/main/java/seedu/restaurant/logic/commands/ingredient/EditIngredientCommand.java
@@ -2,6 +2,7 @@ package seedu.restaurant.logic.commands.ingredient;
 
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_MINIMUM;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
+import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_ORIGINAL_NAME;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_PRICE;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
 
@@ -30,14 +31,19 @@ public abstract class EditIngredientCommand extends Command {
     public static final String COMMAND_ALIAS = "edit-ing";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the ingredient identified "
-            + "by the index number used in the displayed ingredient list. "
+            + "by the index number used in the displayed ingredient list or its name. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: [INDEX (must be a positive integer)] "
+            + "[" + PREFIX_INGREDIENT_ORIGINAL_NAME + "ORIGINAL_NAME] "
             + "[" + PREFIX_INGREDIENT_NAME + "NAME] "
             + "[" + PREFIX_INGREDIENT_UNIT + "UNIT] "
             + "[" + PREFIX_INGREDIENT_PRICE + "PRICE] "
             + "[" + PREFIX_INGREDIENT_MINIMUM + "MINIMUM] "
             + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_INGREDIENT_PRICE + "$5.60 "
+            + PREFIX_INGREDIENT_MINIMUM + "15 "
+            + "OR " + COMMAND_WORD + " "
+            + PREFIX_INGREDIENT_ORIGINAL_NAME + "chicken "
             + PREFIX_INGREDIENT_PRICE + "$5.60 "
             + PREFIX_INGREDIENT_MINIMUM + "15";
 

--- a/src/main/java/seedu/restaurant/logic/parser/ingredient/EditIngredientCommandParser.java
+++ b/src/main/java/seedu/restaurant/logic/parser/ingredient/EditIngredientCommandParser.java
@@ -43,12 +43,10 @@ public class EditIngredientCommandParser implements Parser<EditIngredientCommand
                 ArgumentTokenizer.tokenize(args, PREFIX_INGREDIENT_ORIGINAL_NAME, PREFIX_INGREDIENT_NAME,
                         PREFIX_INGREDIENT_UNIT, PREFIX_INGREDIENT_PRICE, PREFIX_INGREDIENT_MINIMUM);
 
-//        String indexOrNameArg = argMultimap.getValue(PREFIX_INGREDIENT_ORIGINAL_NAME).orElse(argMultimap.getPreamble());
-//
-//        if (indexOrNameArg.trim().isEmpty()) {
-//            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-//                    EditIngredientCommand.MESSAGE_USAGE));
-//        }
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditIngredientCommand.MESSAGE_USAGE));
+        }
 //
 //        Object indexOrName = IngredientParserUtil.parseIndexOrIngredientName(indexOrNameArg);
 

--- a/src/main/java/seedu/restaurant/logic/parser/ingredient/EditIngredientCommandParser.java
+++ b/src/main/java/seedu/restaurant/logic/parser/ingredient/EditIngredientCommandParser.java
@@ -2,10 +2,17 @@ package seedu.restaurant.logic.parser.ingredient;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.restaurant.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.restaurant.commons.util.StringUtil.isNonZeroUnsignedInteger;
+import static seedu.restaurant.logic.parser.ingredient.IngredientParserUtil.MESSAGE_NOT_INDEX_OR_NAME;
+import static seedu.restaurant.logic.parser.ingredient.IngredientParserUtil.parseIngredientName;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_MINIMUM;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
+import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_ORIGINAL_NAME;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_PRICE;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
+import static seedu.restaurant.logic.parser.util.ParserUtil.parseIndex;
+
+import java.util.Optional;
 
 import seedu.restaurant.commons.core.index.Index;
 import seedu.restaurant.logic.commands.ingredient.EditIngredientByIndexCommand;
@@ -16,6 +23,7 @@ import seedu.restaurant.logic.parser.Parser;
 import seedu.restaurant.logic.parser.exceptions.ParseException;
 import seedu.restaurant.logic.parser.util.ArgumentMultimap;
 import seedu.restaurant.logic.parser.util.ArgumentTokenizer;
+import seedu.restaurant.model.ingredient.Ingredient;
 import seedu.restaurant.model.ingredient.IngredientName;
 
 /**
@@ -32,17 +40,17 @@ public class EditIngredientCommandParser implements Parser<EditIngredientCommand
     public EditIngredientCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_UNIT,
-                        PREFIX_INGREDIENT_PRICE, PREFIX_INGREDIENT_MINIMUM);
+                ArgumentTokenizer.tokenize(args, PREFIX_INGREDIENT_ORIGINAL_NAME, PREFIX_INGREDIENT_NAME,
+                        PREFIX_INGREDIENT_UNIT, PREFIX_INGREDIENT_PRICE, PREFIX_INGREDIENT_MINIMUM);
 
-        String indexOrNameArg = argMultimap.getPreamble();
-
-        if (indexOrNameArg.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditIngredientCommand.MESSAGE_USAGE));
-        }
-
-        Object indexOrName = IngredientParserUtil.parseIndexOrIngredientName(indexOrNameArg);
+//        String indexOrNameArg = argMultimap.getValue(PREFIX_INGREDIENT_ORIGINAL_NAME).orElse(argMultimap.getPreamble());
+//
+//        if (indexOrNameArg.trim().isEmpty()) {
+//            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+//                    EditIngredientCommand.MESSAGE_USAGE));
+//        }
+//
+//        Object indexOrName = IngredientParserUtil.parseIndexOrIngredientName(indexOrNameArg);
 
         EditIngredientDescriptor editIngredientDescriptor = new EditIngredientDescriptor();
         setNameDescriptor(argMultimap, editIngredientDescriptor);
@@ -55,17 +63,32 @@ public class EditIngredientCommandParser implements Parser<EditIngredientCommand
         }
 
         EditIngredientCommand editCommand = null;
-        Index index;
-        IngredientName name;
+//        Index index;
+//        IngredientName name;
 
-        if (indexOrName instanceof Index) {
-            index = (Index) indexOrName;
+        String trimmedIndex = argMultimap.getPreamble().trim();
+        if (!trimmedIndex.trim().isEmpty() && isNonZeroUnsignedInteger(trimmedIndex)) {
+            Index index = parseIndex(trimmedIndex);
             editCommand = new EditIngredientByIndexCommand(index, editIngredientDescriptor);
-        }
-        if (indexOrName instanceof IngredientName) {
-            name = (IngredientName) indexOrName;
+        } else {
+            String originalName = argMultimap.getValue(PREFIX_INGREDIENT_ORIGINAL_NAME).orElse("");
+            if (originalName.isEmpty()) {
+                throw new ParseException(MESSAGE_NOT_INDEX_OR_NAME + "\n" +
+                        EditIngredientCommand.MESSAGE_USAGE);
+            }
+            IngredientName name = parseIngredientName(originalName.trim());
             editCommand = new EditIngredientByNameCommand(name, editIngredientDescriptor);
+
         }
+//
+//        if (indexOrName instanceof Index) {
+//            index = (Index) indexOrName;
+//            editCommand = new EditIngredientByIndexCommand(index, editIngredientDescriptor);
+//        }
+//        if (indexOrName instanceof IngredientName) {
+//            name = (IngredientName) indexOrName;
+//            editCommand = new EditIngredientByNameCommand(name, editIngredientDescriptor);
+//        }
 
         return editCommand;
     }

--- a/src/main/java/seedu/restaurant/logic/parser/ingredient/IngredientParserUtil.java
+++ b/src/main/java/seedu/restaurant/logic/parser/ingredient/IngredientParserUtil.java
@@ -16,7 +16,7 @@ import seedu.restaurant.model.ingredient.NumUnits;
  * Contains utility methods used for parsing strings ingredient-related classes.
  */
 public class IngredientParserUtil {
-    public static final String MESSAGE_NOT_INDEX_OR_NAME = "A valid index or ingredient name must be entered.";
+    public static final String MESSAGE_NOT_INDEX_OR_NAME = "A valid index or ingredient name must be entered!";
 
     // This class should not be instantiated.
     private IngredientParserUtil() {

--- a/src/main/java/seedu/restaurant/logic/parser/util/CliSyntax.java
+++ b/src/main/java/seedu/restaurant/logic/parser/util/CliSyntax.java
@@ -30,6 +30,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_INGREDIENT_PRICE = new Prefix("p/");
     public static final Prefix PREFIX_INGREDIENT_MINIMUM = new Prefix("m/");
     public static final Prefix PREFIX_INGREDIENT_NUM = new Prefix("nu/");
+    public static final Prefix PREFIX_INGREDIENT_ORIGINAL_NAME = new Prefix("on/");
 
     /*Prefix definitions for menu management */
     public static final Prefix PREFIX_PRICE = new Prefix("p/");

--- a/src/test/java/seedu/restaurant/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/restaurant/logic/commands/CommandTestUtil.java
@@ -6,6 +6,7 @@ import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_DATE;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_ID;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_MINIMUM;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
+import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_ORIGINAL_NAME;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_PRICE;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
 import static seedu.restaurant.logic.parser.util.CliSyntax.PREFIX_ITEM_NAME;
@@ -147,6 +148,10 @@ public class CommandTestUtil {
     public static final String INGREDIENT_MINIMUM_DESC_APPLE = " " + PREFIX_INGREDIENT_MINIMUM + VALID_MINIMUM_APPLE;
     public static final String INGREDIENT_MINIMUM_DESC_BROCCOLI = " " + PREFIX_INGREDIENT_MINIMUM
             + VALID_MINIMUM_BROCCOLI;
+    public static final String INGREDIENT_ORIGINAL_NAME_DESC_APPLE =
+            " " + PREFIX_INGREDIENT_ORIGINAL_NAME + VALID_NAME_APPLE;
+    public static final String INGREDIENT_ORIGINAL_NAME_DESC_BROCCOLI =
+            " " + PREFIX_INGREDIENT_ORIGINAL_NAME + VALID_NAME_BROCCOLI;
 
     public static final String INVALID_INGREDIENT_NAME_DESC = " " + PREFIX_INGREDIENT_NAME + "Chicken&"; // '&' not
     // allowed in ingredient names
@@ -156,6 +161,9 @@ public class CommandTestUtil {
     // places not allowed for ingredient prices
     public static final String INVALID_INGREDIENT_MINIMUM_DESC = " " + PREFIX_INGREDIENT_MINIMUM + "2.0"; // decimal
     // place not allowed for ingredient minimums
+    public static final String INVALID_INGREDIENT_ORIGINAL_NAME_DESC =
+            " " + PREFIX_INGREDIENT_ORIGINAL_NAME + "Chicken+"; //
+    // '+' not allowed for ingredient names
 
     /**
      * For menu

--- a/src/test/java/seedu/restaurant/logic/parser/RestaurantBookParserTest.java
+++ b/src/test/java/seedu/restaurant/logic/parser/RestaurantBookParserTest.java
@@ -438,13 +438,13 @@ public class RestaurantBookParserTest {
 
         // full command name, edit by name
         command = (EditIngredientByNameCommand) parser.parseCommand(
-                EditIngredientByNameCommand.COMMAND_WORD + " " + "Chicken Thigh"
+                EditIngredientByNameCommand.COMMAND_WORD + " " + "on/Chicken Thigh"
                         + " " + IngredientUtil.getEditIngredientDescriptorDetails(descriptor));
         assertEquals(new EditIngredientByNameCommand(new IngredientName("Chicken Thigh"), descriptor), command);
 
         // command alias, edit by name
         command = (EditIngredientByNameCommand) parser.parseCommand(
-                EditIngredientByNameCommand.COMMAND_ALIAS + " " + "Chicken Thigh"
+                EditIngredientByNameCommand.COMMAND_ALIAS + " " + "on/Chicken Thigh"
                         + " " + IngredientUtil.getEditIngredientDescriptorDetails(descriptor));
         assertEquals(new EditIngredientByNameCommand(new IngredientName("Chicken Thigh"), descriptor), command);
     }

--- a/src/test/java/seedu/restaurant/logic/parser/ingredient/EditIngredientCommandParserTest.java
+++ b/src/test/java/seedu/restaurant/logic/parser/ingredient/EditIngredientCommandParserTest.java
@@ -5,12 +5,15 @@ import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_MINIMUM
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_MINIMUM_DESC_BROCCOLI;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_NAME_DESC_APPLE;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_NAME_DESC_BROCCOLI;
+import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_ORIGINAL_NAME_DESC_APPLE;
+import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_ORIGINAL_NAME_DESC_BROCCOLI;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_PRICE_DESC_APPLE;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_PRICE_DESC_BROCCOLI;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_UNIT_DESC_APPLE;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INGREDIENT_UNIT_DESC_BROCCOLI;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INVALID_INGREDIENT_MINIMUM_DESC;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INVALID_INGREDIENT_NAME_DESC;
+import static seedu.restaurant.logic.commands.CommandTestUtil.INVALID_INGREDIENT_ORIGINAL_NAME_DESC;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INVALID_INGREDIENT_PRICE_DESC;
 import static seedu.restaurant.logic.commands.CommandTestUtil.INVALID_INGREDIENT_UNIT_DESC;
 import static seedu.restaurant.logic.commands.CommandTestUtil.VALID_MINIMUM_APPLE;
@@ -24,6 +27,7 @@ import static seedu.restaurant.logic.commands.CommandTestUtil.VALID_UNIT_BROCCOL
 import static seedu.restaurant.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.restaurant.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.restaurant.logic.parser.ingredient.IngredientParserUtil.MESSAGE_NOT_INDEX_OR_NAME;
+import static seedu.restaurant.model.ingredient.IngredientName.MESSAGE_NAME_CONSTRAINTS;
 import static seedu.restaurant.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.restaurant.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.restaurant.testutil.TypicalIndexes.INDEX_THIRD;
@@ -53,24 +57,33 @@ public class EditIngredientCommandParserTest {
         // no preamble or field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
 
-        // preamble is not index or name
-        assertParseFailure(parser, "1+" + INGREDIENT_UNIT_DESC_BROCCOLI, MESSAGE_NOT_INDEX_OR_NAME);
-        assertParseFailure(parser, "apple+" + INGREDIENT_UNIT_DESC_BROCCOLI, MESSAGE_NOT_INDEX_OR_NAME);
+        // no index or original name specified
+        assertParseFailure(parser, INGREDIENT_NAME_DESC_BROCCOLI, MESSAGE_NOT_INDEX_OR_NAME + "\n"
+                + EditIngredientCommand.MESSAGE_USAGE);
 
         // no preamble but field specified
-        assertParseFailure(parser, INGREDIENT_NAME_DESC_APPLE, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, INGREDIENT_NAME_DESC_APPLE,
+                MESSAGE_NOT_INDEX_OR_NAME + "\n" + EditIngredientCommand.MESSAGE_USAGE);
+
+        // invalid index and original name specified
+        assertParseFailure(parser, "1+" + INGREDIENT_UNIT_DESC_BROCCOLI,
+                MESSAGE_NOT_INDEX_OR_NAME + "\n" + EditIngredientCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, INVALID_INGREDIENT_ORIGINAL_NAME_DESC + INGREDIENT_UNIT_DESC_BROCCOLI,
+                MESSAGE_NAME_CONSTRAINTS);
+        // if both index and name are invalid, error message will relate to name
+        assertParseFailure(parser, "1+ on/broccoli+" + INGREDIENT_UNIT_DESC_BROCCOLI, MESSAGE_NAME_CONSTRAINTS);
 
         // index specified but no field specified
         assertParseFailure(parser, "1", EditIngredientByIndexCommand.MESSAGE_NOT_EDITED);
 
         // name specified but no field specified
-        assertParseFailure(parser, VALID_NAME_APPLE, EditIngredientByIndexCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE, EditIngredientByIndexCommand.MESSAGE_NOT_EDITED);
     }
 
     @Test
-    public void parse_indexWithInvalidValue_failure() {
+    public void parse_validIndexWithInvalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_INGREDIENT_NAME_DESC,
-                IngredientName.MESSAGE_NAME_CONSTRAINTS); // invalid name
+                MESSAGE_NAME_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_INGREDIENT_UNIT_DESC,
                 IngredientUnit.MESSAGE_UNIT_CONSTRAINTS); // invalid unit
         assertParseFailure(parser, "1" + INVALID_INGREDIENT_PRICE_DESC,
@@ -89,32 +102,32 @@ public class EditIngredientCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_INGREDIENT_NAME_DESC + INVALID_INGREDIENT_UNIT_DESC,
-                IngredientName.MESSAGE_NAME_CONSTRAINTS);
+                MESSAGE_NAME_CONSTRAINTS);
     }
 
     @Test
     public void parse_nameWithInvalidValue_failure() {
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INVALID_INGREDIENT_NAME_DESC,
-                IngredientName.MESSAGE_NAME_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INVALID_INGREDIENT_UNIT_DESC,
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_NAME_DESC,
+                MESSAGE_NAME_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_UNIT_DESC,
                 IngredientUnit.MESSAGE_UNIT_CONSTRAINTS); // invalid unit
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INVALID_INGREDIENT_PRICE_DESC,
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_PRICE_DESC,
                 IngredientPrice.MESSAGE_PRICE_CONSTRAINTS); // invalid price
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INVALID_INGREDIENT_MINIMUM_DESC,
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_MINIMUM_DESC,
                 MinimumUnit.MESSAGE_MINIMUM_CONSTRAINTS); // invalid minimum
 
         // invalid unit followed by valid price
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INVALID_INGREDIENT_UNIT_DESC
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_UNIT_DESC
                 + INGREDIENT_PRICE_DESC_APPLE, IngredientUnit.MESSAGE_UNIT_CONSTRAINTS);
 
         // valid value followed by invalid value. The test case for invalid value followed by valid value
         // is tested at {@code parse_name_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INGREDIENT_UNIT_DESC_BROCCOLI
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INGREDIENT_UNIT_DESC_BROCCOLI
                 + INVALID_INGREDIENT_UNIT_DESC, IngredientUnit.MESSAGE_UNIT_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, VALID_NAME_BROCCOLI + INVALID_INGREDIENT_NAME_DESC
-                + INVALID_INGREDIENT_UNIT_DESC, IngredientName.MESSAGE_NAME_CONSTRAINTS);
+        assertParseFailure(parser, INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_NAME_DESC
+                + INVALID_INGREDIENT_UNIT_DESC, MESSAGE_NAME_CONSTRAINTS);
     }
 
     @Test
@@ -134,8 +147,8 @@ public class EditIngredientCommandParserTest {
     @Test
     public void parse_nameWithAllFieldsSpecified_success() {
         IngredientName targetName = new IngredientName(VALID_NAME_APPLE);
-        String userInput = VALID_NAME_APPLE + " " + INGREDIENT_UNIT_DESC_BROCCOLI + INGREDIENT_PRICE_DESC_APPLE
-                + INGREDIENT_MINIMUM_DESC_BROCCOLI + INGREDIENT_NAME_DESC_BROCCOLI;
+        String userInput = INGREDIENT_ORIGINAL_NAME_DESC_APPLE + " " + INGREDIENT_UNIT_DESC_BROCCOLI
+                + INGREDIENT_PRICE_DESC_APPLE + INGREDIENT_MINIMUM_DESC_BROCCOLI + INGREDIENT_NAME_DESC_BROCCOLI;
 
         EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder().withName(VALID_NAME_BROCCOLI)
                 .withUnit(VALID_UNIT_BROCCOLI).withPrice(VALID_PRICE_APPLE)
@@ -160,7 +173,8 @@ public class EditIngredientCommandParserTest {
     @Test
     public void parse_nameWithSomeFieldsSpecified_success() {
         IngredientName targetName = new IngredientName(VALID_NAME_APPLE);
-        String userInput = VALID_NAME_APPLE + " " + INGREDIENT_UNIT_DESC_APPLE + INGREDIENT_PRICE_DESC_BROCCOLI;
+        String userInput = INGREDIENT_ORIGINAL_NAME_DESC_APPLE + " " + INGREDIENT_UNIT_DESC_APPLE
+                + INGREDIENT_PRICE_DESC_BROCCOLI;
 
         EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder().withUnit(VALID_UNIT_APPLE)
                 .withPrice(VALID_PRICE_BROCCOLI).build();
@@ -202,28 +216,28 @@ public class EditIngredientCommandParserTest {
     public void parse_nameWithOneFieldSpecified_success() {
         // name
         IngredientName targetName = new IngredientName(VALID_NAME_BROCCOLI);
-        String userInput = VALID_NAME_BROCCOLI + " " + INGREDIENT_NAME_DESC_APPLE;
+        String userInput = INGREDIENT_ORIGINAL_NAME_DESC_BROCCOLI + " " + INGREDIENT_NAME_DESC_APPLE;
         EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder()
                 .withName(VALID_NAME_APPLE).build();
         EditIngredientCommand expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // unit
-        userInput = VALID_NAME_BROCCOLI + " " + INGREDIENT_UNIT_DESC_APPLE;
+        userInput = INGREDIENT_ORIGINAL_NAME_DESC_BROCCOLI + " " + INGREDIENT_UNIT_DESC_APPLE;
         descriptor = new EditIngredientDescriptorBuilder()
                 .withUnit(VALID_UNIT_APPLE).build();
         expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // price
-        userInput = VALID_NAME_BROCCOLI + " " + INGREDIENT_PRICE_DESC_APPLE;
+        userInput = INGREDIENT_ORIGINAL_NAME_DESC_BROCCOLI + " " + INGREDIENT_PRICE_DESC_APPLE;
         descriptor = new EditIngredientDescriptorBuilder()
                 .withPrice(VALID_PRICE_APPLE).build();
         expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // minimum
-        userInput = VALID_NAME_BROCCOLI + " " + INGREDIENT_MINIMUM_DESC_APPLE;
+        userInput = INGREDIENT_ORIGINAL_NAME_DESC_BROCCOLI + " " + INGREDIENT_MINIMUM_DESC_APPLE;
         descriptor = new EditIngredientDescriptorBuilder()
                 .withMinimum(VALID_MINIMUM_APPLE).build();
         expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
@@ -250,7 +264,8 @@ public class EditIngredientCommandParserTest {
     @Test
     public void parse_nameWithMultipleRepeatedFields_acceptsLast() {
         IngredientName targetName = new IngredientName(VALID_NAME_APPLE);
-        String userInput = VALID_NAME_APPLE + " " + INGREDIENT_UNIT_DESC_APPLE + INGREDIENT_MINIMUM_DESC_APPLE
+        String userInput =
+                INGREDIENT_ORIGINAL_NAME_DESC_APPLE + " " + INGREDIENT_UNIT_DESC_APPLE + INGREDIENT_MINIMUM_DESC_APPLE
                 + INGREDIENT_PRICE_DESC_APPLE + INGREDIENT_UNIT_DESC_APPLE + INGREDIENT_MINIMUM_DESC_APPLE
                 + INGREDIENT_PRICE_DESC_APPLE + INGREDIENT_UNIT_DESC_BROCCOLI + INGREDIENT_MINIMUM_DESC_BROCCOLI
                 + INGREDIENT_PRICE_DESC_BROCCOLI;
@@ -286,18 +301,54 @@ public class EditIngredientCommandParserTest {
     public void parse_nameWithInvalidValueFollowedByValidValue_success() {
         // no other valid values specified
         IngredientName targetName = new IngredientName(VALID_NAME_APPLE);
-        String userInput = VALID_NAME_APPLE + INVALID_INGREDIENT_UNIT_DESC + INGREDIENT_UNIT_DESC_BROCCOLI;
+        String userInput = INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INVALID_INGREDIENT_UNIT_DESC
+                + INGREDIENT_UNIT_DESC_BROCCOLI;
         EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder().withUnit(VALID_UNIT_BROCCOLI)
                 .build();
         EditIngredientCommand expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
-        userInput = VALID_NAME_APPLE + INGREDIENT_PRICE_DESC_BROCCOLI + INVALID_INGREDIENT_UNIT_DESC
+        userInput = INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INGREDIENT_PRICE_DESC_BROCCOLI + INVALID_INGREDIENT_UNIT_DESC
                 + INGREDIENT_MINIMUM_DESC_BROCCOLI + INGREDIENT_UNIT_DESC_BROCCOLI;
         descriptor = new EditIngredientDescriptorBuilder().withUnit(VALID_UNIT_BROCCOLI).withPrice(VALID_PRICE_BROCCOLI)
                 .withMinimum(VALID_MINIMUM_BROCCOLI).build();
         expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validIndexWithInvalidName_success() {
+        // edit by index if it is valid (even if specified name is valid)
+        Index targetIndex = INDEX_FIRST;
+        String userInput =
+                targetIndex.getOneBased() + INVALID_INGREDIENT_ORIGINAL_NAME_DESC + INGREDIENT_UNIT_DESC_BROCCOLI;
+        EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder().withUnit(VALID_UNIT_BROCCOLI)
+                .build();
+        EditIngredientCommand expectedCommand = new EditIngredientByIndexCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidIndexWithValidName_success() {
+        // edit by name if index is invalid
+        IngredientName targetName = new IngredientName(VALID_NAME_APPLE);
+        String userInput = "1+ " + INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INGREDIENT_UNIT_DESC_BROCCOLI;
+        EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder().withUnit(VALID_UNIT_BROCCOLI)
+                .build();
+        EditIngredientCommand expectedCommand = new EditIngredientByNameCommand(targetName, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validIndexWithValidName_success() {
+        // edit by index if both index and name specified are valid
+        Index targetIndex = INDEX_FIRST;
+        String userInput =
+                targetIndex.getOneBased() + INGREDIENT_ORIGINAL_NAME_DESC_APPLE + INGREDIENT_UNIT_DESC_BROCCOLI;
+        EditIngredientDescriptor descriptor = new EditIngredientDescriptorBuilder().withUnit(VALID_UNIT_BROCCOLI)
+                .build();
+        EditIngredientCommand expectedCommand = new EditIngredientByIndexCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 }


### PR DESCRIPTION
1) Fixes #245 
Implementation of  `edit-ing`:
- if specified index is valid, edit ingredient by index
- if specified index is invalid, but valid name specified by prefix "on/", edit ingredient by name
- if specified index is invalid and no name or invalid name specified by prefix "on", return parse error
- if both index and name specified are valid, edit ingredient by index